### PR TITLE
Fix typo in instantaneous

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,45 +81,45 @@ All sensors are optional.
 ```yaml
   - platform: victron_smart_shunt
     battery_voltage:
-      name: "Battery Voltage"  
+      name: "Battery Voltage"
       id: bv
 
     battery_current:
-      name: "Battery Current" 
+      name: "Battery Current"
       id: bc
 
     fw_version:
-      name: "fw"  
+      name: "fw"
       id: fw
 
     pid:
-      name: "pid"  
+      name: "pid"
       id: pid
 
     instantaneous_power:
-      name: "instantaneous power"  
-      id: instantaneous_power      
+      name: "instantaneous power"
+      id: instantaneous_power
 
     time_to_go:
-      name: "time to go"  
+      name: "time to go"
       id: time_to_go
 
     consumed_amp_hours:
       name: "consumed amp hours"
-      id: consumed_amp_hours  
+      id: consumed_amp_hours
       unit_of_measurement: Ah
 
     min_battery_voltage:
       name: "Min battery voltage"
-      id: min_battery_voltage   
+      id: min_battery_voltage
 
-    max_battery_voltage: 
+    max_battery_voltage:
       name: "Max battery voltage"
-      id: max_battery_voltage     
+      id: max_battery_voltage
 
     amount_of_charged:
       name: "Amount of charged"
-      id:  amount_of_charged   
+      id:  amount_of_charged
       filters:
         - multiply: 0.001
       unit_of_measurement: kWh
@@ -127,7 +127,7 @@ All sensors are optional.
     bmv_alarm:
       name: "BMV alarm"
       id: bmv_alarm
-      
+
     bmv_pid:
       name: "bmv - pid"
       id: bmv_pid
@@ -138,7 +138,7 @@ All sensors are optional.
 
     deepest_discharge:
       name: "Depth of the deepest discharge"
-      id: deepest_discharge   
+      id: deepest_discharge
       unit_of_measurement: Ah
 
     last_discharge:
@@ -148,17 +148,17 @@ All sensors are optional.
 
     discharged_energy:
       name: "Amount of discharged energy"
-      id: discharged_energy   
+      id: discharged_energy
       filters:
         - multiply: 0.001
       unit_of_measurement: kWh
 
     state_of_charge:
       id: state_of_charge
-      name: "SoC"  
+      name: "SoC"
 ```
 The available numeric sensors are:
-- `instanteneous_power`
+- `instantaneous_power`
 - `time_to_go`
 - `state_of_charge`
 - `consumed_amp_hours`
@@ -191,4 +191,4 @@ Full example in `smartshunt.yaml`
 `Big thanks for help to ssieb`
 
 ```
-#victron #esphome #smartshunt #bmv #ve.direct 
+#victron #esphome #smartshunt #bmv #ve.direct

--- a/components/victron_smart_shunt/sensor.py
+++ b/components/victron_smart_shunt/sensor.py
@@ -25,7 +25,7 @@ from esphome.const import (
 
 from . import CONF_VICTRON_SMART_SHUNT_ID, VictronSmartShuntComponent
 
-CONF_INSTANTENEOUS_POWER = "instanteneous_power"
+CONF_INSTANTANEOUS_POWER = "instantaneous_power"
 CONF_TIME_TO_GO = "time_to_go"
 CONF_STATE_OF_CHARGE = "state_of_charge"
 CONF_CONSUMED_AMP_HOURS = "consumed_amp_hours"
@@ -171,7 +171,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_PID): text_sensor.TEXT_SENSOR_SCHEMA.extend(
             {cv.GenerateID(): cv.declare_id(text_sensor.TextSensor)}
         ),
-        cv.Optional(CONF_INSTANTENEOUS_POWER): sensor.sensor_schema(
+        cv.Optional(CONF_INSTANTANEOUS_POWER): sensor.sensor_schema(
             unit_of_measurement=UNIT_WATT,
             icon=ICON_POWER,
             accuracy_decimals=0,
@@ -354,8 +354,8 @@ def to_code(config):
         yield text_sensor.register_text_sensor(sens, conf)
         cg.add(var.set_pid_sensor(sens))
 
-    if CONF_INSTANTENEOUS_POWER in config:
-        sens = yield sensor.new_sensor(config[CONF_INSTANTENEOUS_POWER])
+    if CONF_INSTANTANEOUS_POWER in config:
+        sens = yield sensor.new_sensor(config[CONF_INSTANTANEOUS_POWER])
         cg.add(var.set_instantaneous_power_sensor(sens))
 
     if CONF_TIME_TO_GO in config:

--- a/esp8266-example-advanced.yaml
+++ b/esp8266-example-advanced.yaml
@@ -98,8 +98,8 @@ sensor:
       name: "pid"
       id: pid
 
-    instanteneous_power:
-      name: "instanteneous power"
+    instantaneous_power:
+      name: "instantaneous power"
       id: instantaneous_power
       accuracy_decimals: ${accuracy}
 


### PR DESCRIPTION
Thank you for this amazing project!

Just fixing a minor typo. Validated this way https://github.com/yoannchaudet/ESPHome-configuration/blob/e6c90b78f7b12b94a25da9e6fff9f8ae660733fe/device.shed-controller.yaml#L79.

![image](https://user-images.githubusercontent.com/14911070/209452230-dc2bbab2-b055-4f94-8ebc-a0f3c7848647.png)

It's a breaking change since the typo was in the sensor name.